### PR TITLE
Adding CI action to build a subproject

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_ROOT="${SCRIPT_DIR}/../.."
+
+cd "${PROJECT_ROOT}/app" || exit 1
+npm install || exit 2
+npm run build || exit 3
+npm run lint:nofix || exit 4

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1,0 +1,34 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x, 23.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      # We wrap the build in a shell script rather than built-in actions since our project is
+      # in a subfolder and GitHub CI no longer supports "working-dir"
+      - name: Build the main app
+        run: |
+          chmod 755 ./.github/scripts/build.sh
+          ./.github/scripts/build.sh
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # stock-pick-challenge
+![Java Build](https://github.com/bobbylight/stock-pick-challenge/actions/workflows/build-app.yml/badge.svg)
+
 A simple application to see who is the better stock picker, me or my wife.
 
 ## What it does

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "serve": "vite preview",
     "test:unit": "vue-cli-service test:unit",
-    "lint": "eslint --ignore-pattern ../.gitignore --fix src"
+    "lint": "eslint --ignore-pattern ../.gitignore --fix src",
+    "lint:nofix": "eslint --ignore-pattern ../.gitignore --max-warnings=0 src"
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Add a CI action to build and lint the project. Since the main source is in a subfolder, we'll have to wrap the logic into a shell script, since GitHub actions no longer support `working-dir` :(