### PR TITLE
fix: Daily changes for stocks on foreign exchanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ allows us to compare the performance of our picks. Prior years are preserved for
 humiliation.
 
 The app loads the data from JSON files that are updated each trading day by an AWS lambda.
-The lambda code lives in `datagen/`, and it can be run locally to test the app before pushing
-changes.
+The lambda code lives in `datagen/`, and it can be run locally to test the app with the
+latest data before pushing changes.
 
 ## Project structure
 * `app/` - The web application. Written in Vue and packaged with Vite


### PR DESCRIPTION
We have a bug where stocks on foreign exchanges, such as `LUN.TO`, would fail the "still actively traded" check due to the Toronto exchange running on US holidays (and the opposite could happen as well). We can't check for an "active" ticker by looking at just the number of trading days we have data for. The fix is to look at the last actual date we have data for and make sure it's >= the last US trading day.