### PR TITLE
docs: Add Claude Code PR command and contribution guidelines

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,33 @@
+# Create a Pull Request
+
+Create a branch (if needed), commit staged/unstaged changes, push, and open a PR.
+
+## Steps
+
+1. **Check branch status**: Run `git status` and `git branch --show-current`
+   - If on `master` or `main`, create a new branch:
+     - Analyze the changes to determine a descriptive branch name
+     - Use lower-kebab-case (e.g., `add-user-authentication`, `fix-login-bug`)
+     - Run `git checkout -b <branch-name>`
+   - If already on a feature branch, continue on that branch
+
+2. **Review changes**: Run `git status` and `git diff` to understand what will be committed
+
+3. **Stage and commit**:
+   - Stage relevant files (prefer specific files over `git add -A`)
+   - Write a commit message using the [conventional commit style](https://www.conventionalcommits.org/en/v1.0.0/)
+     - Don't read the conventional commit site/URL if you already know the style
+     - Use "!" after the type to indicate a breaking change
+     - Use "build(deps)" for dependency bumps
+     - Besides dependencies, don't worry too much about adding a scope to the commit type unless it's a larger
+       change concentrated on a specific component or area
+   - Include `Co-Authored-By: Claude <noreply@anthropic.com>` in the commit
+
+4. **Push**: Run `git push -u origin <branch-name>`
+
+5. **Create PR**: Use `gh pr create` with:
+   - A concise title matching the commit style
+   - A body with `## Summary` (bullet points) and `## Test plan` sections
+   - Footer: `🤖 Generated with [Claude Code](https://claude.ai/claude-code)`
+
+If any step fails, report the error and ask how to proceed.

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ deployment-package.zip
 .env.local
 .env.*.local
 
+# claude files not to be committed
+.claude/settings.local.json
+
 # Editor directories and files
 .idea
 *.iml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,12 @@ cd ../app && npm run dev
 - The 2026 data in the repo may be stale; run `generate-local-data` for latest
 - App is 100% static, deployed to S3
 - Lambda needs S3 PutObject access to `data/<year>/*`
+
+## Submitting PRs
+
+- Use conventional commit syntax (feat:, fix:, chore:, docs:, refactor:, test:, etc.)
+- Ensure tests pass before committing and fix anything if necessary. If any tests
+  needed fixing, let me review the changes before proceeding with the commit.
+- Commit messages don't need to mention tests being added. Only mention tests when a
+  large amount of tests were added for previously uncovered code, or there was a
+  major refactoring of test code.


### PR DESCRIPTION
## Summary

- Add `/pr` slash command for Claude Code to automate PR creation workflow
- Add PR submission guidelines to `CLAUDE.md` (conventional commits, test requirements)
- Exclude `.claude/settings.local.json` from version control in `.gitignore`

## Test plan

- [x] Verify `.claude/commands/pr.md` is correctly formatted
- [x] Verify `CLAUDE.md` updates render properly
- [x] Verify `.gitignore` entry excludes the correct file

🤖 Generated with [Claude Code](https://claude.ai/claude-code)