### PR TITLE
feat: Add chart dark mode support and progressive line animation

### DIFF
--- a/app/src/chart-animation.js
+++ b/app/src/chart-animation.js
@@ -1,0 +1,37 @@
+const delayBetweenPoints = 16
+
+export const tickColor = isDark => isDark ? '#cbd5e1' : undefined
+export const gridColor = isDark => isDark ? '#334155' : undefined
+
+export const progressiveLineAnimation = {
+  x: {
+    type: 'number',
+    easing: 'linear',
+    duration: delayBetweenPoints,
+    from: NaN, // point not drawn until its turn
+    delay(ctx) {
+      if (ctx.type !== 'data' || ctx.xStarted) {
+        return 0
+      }
+      ctx.xStarted = true
+      return ctx.index * delayBetweenPoints
+    },
+  },
+  y: {
+    type: 'number',
+    easing: 'linear',
+    duration: delayBetweenPoints,
+    from: ctx => {
+      const prevIndex = ctx.index - 1
+      const dataset = ctx.chart.data.datasets[ctx.datasetIndex]
+      return prevIndex >= 0 ? dataset.data[prevIndex] : ctx.chart.scales.y.getPixelForValue(dataset.data[0])
+    },
+    delay(ctx) {
+      if (ctx.type !== 'data' || ctx.yStarted) {
+        return 0
+      }
+      ctx.yStarted = true
+      return ctx.index * delayBetweenPoints
+    },
+  },
+}

--- a/app/src/comparison-chart.vue
+++ b/app/src/comparison-chart.vue
@@ -22,6 +22,7 @@ import { useDisplay, useTheme } from 'vuetify'
 import Chart from 'chart.js/auto'
 import { currency, percentage } from './app-filters'
 import PortfolioGrowthChartTooltip from './portfolio-growth-chart-tooltip.vue'
+import { progressiveLineAnimation, tickColor, gridColor } from './chart-animation'
 
 const display = useDisplay()
 const vuetifyTheme = useTheme()
@@ -145,6 +146,18 @@ watch(dayCountRef, () => {
   updateChartDataForNewDataType()
 })
 
+watch(() => vuetifyTheme.global.name.value, () => {
+  const isDark = vuetifyTheme.global.name.value === 'dark'
+  const tColor = tickColor(isDark)
+  const gColor = gridColor(isDark)
+  chart.value.options.scales.x.ticks.color = tColor
+  chart.value.options.scales.y.ticks.color = tColor
+  chart.value.options.scales.x.grid.color = gColor
+  chart.value.options.scales.y.grid.color = gColor
+  chart.value.options.plugins.legend.labels.color = tColor
+  chart.value.update()
+})
+
 onMounted(() => {
   const initialDatasets = props.userInfos.map((userInfo, index) => {
     return {
@@ -188,12 +201,20 @@ onMounted(() => {
     ],
     options: {
 
+      animation: progressiveLineAnimation,
+
       interaction: {
         mode: 'index',
         intersect: false,
       },
 
       plugins: {
+
+        legend: {
+          labels: {
+            color: tickColor(vuetifyTheme.global.name.value === 'dark'),
+          },
+        },
 
         tooltip: {
           mode: 'index', // Show all dataset values for this x-coordinate
@@ -224,7 +245,11 @@ onMounted(() => {
 
       scales: {
         x: {
+          grid: {
+            color: gridColor(vuetifyTheme.global.name.value === 'dark'),
+          },
           ticks: {
+            color: tickColor(vuetifyTheme.global.name.value === 'dark'),
             maxTicksLimit: 10,
             callback: function (index, value) {
               // Abbreviate the year, but keep label array using 4-digit year for tooltip
@@ -233,7 +258,11 @@ onMounted(() => {
           },
         },
         y: {
+          grid: {
+            color: gridColor(vuetifyTheme.global.name.value === 'dark'),
+          },
           ticks: {
+            color: tickColor(vuetifyTheme.global.name.value === 'dark'),
             callback: currencyYAxisLabelCallback,
           },
         },

--- a/app/src/portfolio-growth-chart-tooltip.vue
+++ b/app/src/portfolio-growth-chart-tooltip.vue
@@ -126,10 +126,21 @@ const title = () => lastTitle.value = props.visible && props.model ? props.model
 
 <style scoped>
 .chart-tooltip-wrapper {
+  --tooltip-bg: #1e293be8;
+  --tooltip-text: #ffffff;
+  --color-square-border: #e0e0e080;
   font-size: smaller;
   position: absolute;
   pointer-events: none;
   display: table;
+}
+
+.v-theme--dark {
+  .chart-tooltip-wrapper {
+    --tooltip-bg: #334155e8;
+    --tooltip-text: #e2e8f0;
+    --color-square-border: #94a3b840;
+  }
 }
 
 .arrow-wrapper {
@@ -137,7 +148,7 @@ const title = () => lastTitle.value = props.visible && props.model ? props.model
   vertical-align: middle;
 }
 .chart-tooltip-arrow {
-  background: #1e293be8;
+  background: var(--tooltip-bg);
   width: 1rem;
   height: 1rem;
 }
@@ -150,8 +161,8 @@ const title = () => lastTitle.value = props.visible && props.model ? props.model
 
 .portfolio-growth-chart-tooltip {
   display:table-cell;
-  background: #1e293be8;
-  color: white;
+  background: var(--tooltip-bg);
+  color: var(--tooltip-text);
   padding: .5rem .75rem;
   border-radius: 8px;
   backdrop-filter: blur(4px);
@@ -171,7 +182,7 @@ const title = () => lastTitle.value = props.visible && props.model ? props.model
   height: 1rem;
   display: inline-block;
   vertical-align: text-bottom;
-  border: 1px solid #e0e0e080;
+  border: 1px solid var(--color-square-border);
 }
 
 .stocky-dataset-label {

--- a/app/src/portfolio-growth-chart.vue
+++ b/app/src/portfolio-growth-chart.vue
@@ -25,6 +25,7 @@ import Chart from 'chart.js/auto'
 import { currency, percentage } from './app-filters'
 import PortfolioGrowthChartTooltip from './portfolio-growth-chart-tooltip.vue'
 import benchmarkData from '@/benchmark-data'
+import { progressiveLineAnimation, tickColor, gridColor } from './chart-animation'
 
 const store = useStore()
 const route = useRoute()
@@ -263,6 +264,18 @@ watch(comparisonsRef, () => {
   chart.value.update()
 })
 
+watch(() => vuetifyTheme.global.name.value, () => {
+  const isDark = vuetifyTheme.global.name.value === 'dark'
+  const tColor = tickColor(isDark)
+  const gColor = gridColor(isDark)
+  chart.value.options.scales.x.ticks.color = tColor
+  chart.value.options.scales.y.ticks.color = tColor
+  chart.value.options.scales.x.grid.color = gColor
+  chart.value.options.scales.y.grid.color = gColor
+  chart.value.options.plugins.legend.labels.color = tColor
+  chart.value.update()
+})
+
 // We must watch for route updates since our chart isn't bound
 // to data and won't know to rerender when switching between
 // users' pages
@@ -305,12 +318,20 @@ onMounted(() => {
     ],
     options: {
 
+      animation: progressiveLineAnimation,
+
       interaction: {
         mode: 'index',
         intersect: false,
       },
 
       plugins: {
+
+        legend: {
+          labels: {
+            color: tickColor(vuetifyTheme.global.name.value === 'dark'),
+          },
+        },
 
         tooltip: {
           mode: 'index', // Show all dataset values for this x-coordinate
@@ -342,7 +363,11 @@ onMounted(() => {
 
       scales: {
         x: {
+          grid: {
+            color: gridColor(vuetifyTheme.global.name.value === 'dark'),
+          },
           ticks: {
+            color: tickColor(vuetifyTheme.global.name.value === 'dark'),
             maxTicksLimit: 10,
             callback: function (index, value) {
               // Abbreviate the year, but keep label array using 4-digit year for tooltip
@@ -351,7 +376,11 @@ onMounted(() => {
           },
         },
         y: {
+          grid: {
+            color: gridColor(vuetifyTheme.global.name.value === 'dark'),
+          },
           ticks: {
+            color: tickColor(vuetifyTheme.global.name.value === 'dark'),
             callback: percentages.value
               ? percentageYAxisLabelCallback
               : currencyYAxisLabelCallback,


### PR DESCRIPTION
## Summary
Color tweaks to make dark mode look a little better.

- Add progressive line-drawing animation to both portfolio growth charts via a shared `chart-animation.js` module
- Add theme-aware colors for chart axes tick labels, grid lines, and legend labels that update reactively on dark/light mode toggle
- Add dark mode CSS variables for chart tooltips (background, text, color square border)

## Test plan

- [x] Verify charts animate with a progressive line-drawing effect on load
- [x] Toggle dark/light mode and confirm chart axes, grid lines, legend labels, and tooltips update colors correctly
- [x] Check both the head-to-head comparison chart and individual portfolio growth chart

🤖 Generated with [Claude Code](https://claude.ai/claude-code)