### PR TITLE
fix: Resolve top performers chart animation and improve labels

### DIFF
--- a/app/src/top-performers-chart.vue
+++ b/app/src/top-performers-chart.vue
@@ -1,8 +1,6 @@
 <template>
   <canvas
     ref="canvas"
-    width="640"
-    height="520"
   />
 </template>
 
@@ -78,13 +76,14 @@ onMounted(() => {
       }],
     },
     options: {
+      aspectRatio: 1,
       indexAxis: 'y',
       plugins: {
         legend: { display: false },
         datalabels: {
           anchor: 'end',
-          align: 'end',
-          color: tickColor(isDark),
+          align: 'start',
+          color: '#fff',
           font: { weight: 'bold' },
           formatter: value => `${value.toFixed(1)}%`,
         },
@@ -109,7 +108,7 @@ onMounted(() => {
 watch(() => vuetifyTheme.global.name.value, () => {
   const isDark = vuetifyTheme.global.name.value === 'dark'
   const c = chart.value
-  c.options.plugins.datalabels.color = tickColor(isDark)
+  c.options.plugins.datalabels.color = '#fff'
   c.options.scales.x.ticks.color = tickColor(isDark)
   c.options.scales.x.grid.color = gridColor(isDark)
   c.options.scales.y.ticks.color = tickColor(isDark)


### PR DESCRIPTION
The "Top Performers" bar chart wasn't animating when scrolled into view. We want all charts to animate a bit to give the page life and look fun, for some definition of "fun."

## Summary
- Remove explicit canvas `width`/`height` attributes that triggered a Chart.js `ResizeObserver` resize event, which canceled the initial bar animation (the resize transition defaults to `duration: 0`)
- Use `aspectRatio: 1` chart option to maintain the desired chart proportions responsively
- Move datalabels inside bars (`align: 'start'`) with white text to prevent clipping at chart edges

## Test plan
- [x] Navigate to a user portfolio page and scroll to the Top Performers chart — bars should animate on entry
- [x] Refresh the page with the chart visible — animation should still play
- [x] Verify percentage labels render inside bars and are readable on both green/red bars
- [x] Toggle dark/light mode and confirm chart colors update correctly
- [x] Check chart looks correct on both full-width and half-width (md breakpoint) layouts

## Video
![spc-animated-top-performers](https://github.com/user-attachments/assets/5398ea14-b1a9-4e41-95f2-223906892323)


🤖 Generated with [Claude Code](https://claude.ai/claude-code)