### PR TITLE
fix: use ^gspc instead of ^dji for market in daily-change chart

### DIFF
--- a/app/src/daily-change-chart.vue
+++ b/app/src/daily-change-chart.vue
@@ -41,10 +41,10 @@ const computeLatestChange = userIndex => {
 }
 
 const computeMarketChange = () => {
-  const djiHistory = store.history['^dji']?.history
-  if (!djiHistory || djiHistory.length < 2) return 0
-  const prev = djiHistory[djiHistory.length - 2].close
-  const curr = djiHistory[djiHistory.length - 1].close
+  const gspcHistory = store.history['^gspc']?.history
+  if (!gspcHistory || gspcHistory.length < 2) return 0
+  const prev = gspcHistory[gspcHistory.length - 2].close
+  const curr = gspcHistory[gspcHistory.length - 1].close
   return (curr - prev) / prev
 }
 


### PR DESCRIPTION
## Summary

- The daily-change bar chart on the head-to-head page was using the Dow Jones Industrial Average (`^dji`) as the "Market" benchmark
- The Today's Changes card on user detail pages uses the S&P 500 (`^gspc`), causing the two views to show different market percentages for the same day
- Fixed by switching `daily-change-chart.vue` to use `^gspc`, making it consistent with `todays-changes.vue`

## Test plan

- [x] Navigate to the head-to-head page and note the "Market" bar value in the daily-change chart
- [x] Navigate to a user detail page and verify the "Today the overall market went up/down X%" in the Today's Changes card matches the chart

🤖 Generated with [Claude Code](https://claude.ai/claude-code)